### PR TITLE
refactor: update logic of auth

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Toaster } from 'react-hot-toast';
 
 import { useAppDispatch } from 'hooks/redux';
+import { useReadLocalStorage } from 'hooks/useReadLocalStorage';
 
 import { setIsAuth } from 'redux/slices/authSlice';
 
@@ -12,14 +13,17 @@ import FeatureFlagProvider from 'context/featureFlag';
 import ErrorBoundary from 'components/ErrorBoundary';
 import Header from 'components/Header';
 
+import type { User } from 'types/user';
+
 const App = () => {
 	const dispatch = useAppDispatch();
+	const user: User | null = useReadLocalStorage('user');
 
 	useEffect(() => {
-		if (localStorage.getItem('user') !== null) {
-			dispatch(setIsAuth(true));
+		if (user) {
+			dispatch(setIsAuth({ isAuth: true, token: user.token, uid: user.uid }));
 		}
-	}, []);
+	}, [user]);
 
 	return (
 		<FeatureFlagProvider>

--- a/src/hooks/useReadLocalStorage.ts
+++ b/src/hooks/useReadLocalStorage.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useState } from 'react';
+
+type Value<T> = T | null;
+
+export function useReadLocalStorage<T>(key: string): Value<T> {
+	const readValue = useCallback((): Value<T> => {
+		if (typeof window === 'undefined') {
+			return null;
+		}
+
+		try {
+			const item = window.localStorage.getItem(key);
+			return item ? (JSON.parse(item) as T) : null;
+		} catch (error) {
+			return null;
+		}
+	}, [key]);
+
+	const [storedValue, setStoredValue] = useState<Value<T>>(readValue);
+
+	useEffect(() => {
+		setStoredValue(readValue());
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	return storedValue;
+}

--- a/src/redux/actions/authActions.ts
+++ b/src/redux/actions/authActions.ts
@@ -5,6 +5,8 @@ import {
 } from '@firebase/auth';
 import { toast } from 'react-hot-toast';
 
+import { setIsAuth } from 'redux/slices/authSlice';
+
 import { auth } from 'firebase.config';
 
 import type { LoginForm } from 'pages/Public/Login/Login';
@@ -12,7 +14,7 @@ import type { RegistrationForm } from 'pages/Public/Registration/Registration';
 
 export const loginAction = createAsyncThunk(
 	'auth/login',
-	async (args: LoginForm, { rejectWithValue }) => {
+	async (args: LoginForm, { rejectWithValue, dispatch }) => {
 		try {
 			const response = await signInWithEmailAndPassword(
 				auth,
@@ -23,6 +25,8 @@ export const loginAction = createAsyncThunk(
 			const uid = response.user.uid;
 
 			if (response.user) {
+				dispatch(setIsAuth({ isAuth: true, token, uid }));
+
 				localStorage.setItem('user', JSON.stringify({ token, uid }));
 			}
 
@@ -35,7 +39,10 @@ export const loginAction = createAsyncThunk(
 );
 export const registrationAction = createAsyncThunk(
 	'auth/registration',
-	async ({ email, password }: RegistrationForm, { rejectWithValue }) => {
+	async (
+		{ email, password }: RegistrationForm,
+		{ rejectWithValue, dispatch }
+	) => {
 		try {
 			const response = await createUserWithEmailAndPassword(
 				auth,
@@ -46,6 +53,8 @@ export const registrationAction = createAsyncThunk(
 			const uid = response.user.uid;
 
 			if (response.user) {
+				dispatch(setIsAuth({ isAuth: true, token, uid }));
+
 				localStorage.setItem('user', JSON.stringify({ token, uid }));
 				toast.success('Вы успешно зарегистрировались на нашем сайте!');
 			}

--- a/src/redux/slices/authSlice.ts
+++ b/src/redux/slices/authSlice.ts
@@ -5,10 +5,14 @@ import { loginAction, registrationAction } from 'redux/actions/authActions';
 interface AuthSlice {
 	isAuth: boolean;
 	loading: boolean;
+	token: string;
+	uid: string;
 }
 const initialState: AuthSlice = {
 	isAuth: false,
 	loading: false,
+	token: '',
+	uid: '',
 };
 
 const authSlice = createSlice({
@@ -16,7 +20,9 @@ const authSlice = createSlice({
 	initialState,
 	reducers: {
 		setIsAuth: (state, action) => {
-			state.isAuth = action.payload;
+			state.isAuth = action.payload.isAuth;
+			state.token = action.payload.token;
+			state.uid = action.payload.uid;
 		},
 		logoutUser: (state) => {
 			state.isAuth = false;

--- a/src/services/favoritesService.ts
+++ b/src/services/favoritesService.ts
@@ -9,6 +9,7 @@ import {
 import { toMoviesArray } from './transformResponses/favoritesTransformResponse';
 
 import type { Movie } from 'types/movies';
+import type { RootState } from 'redux/store';
 
 const rawBaseQuery = fetchBaseQuery({
 	baseUrl: 'https://aston-movies-default-rtdb.firebaseio.com/',
@@ -19,8 +20,9 @@ const dynamicBaseQuery: BaseQueryFn<
 	unknown,
 	FetchBaseQueryError
 > = async (args, api, extraOptions) => {
-	const { uid, token }: { uid: string; token: string } =
-		JSON.parse(localStorage.getItem('user') as string) || '';
+	const {
+		auth: { token, uid },
+	} = api.getState() as RootState;
 
 	if (!uid || !token) {
 		return {

--- a/src/services/historyService.ts
+++ b/src/services/historyService.ts
@@ -9,6 +9,7 @@ import {
 import { toHistory } from './transformResponses/historyTransformResponse';
 
 import type { History, HistoryForm } from 'types/history';
+import type { RootState } from 'redux/store';
 
 const rawBaseQuery = fetchBaseQuery({
 	baseUrl: 'https://aston-movies-default-rtdb.firebaseio.com/',
@@ -19,8 +20,9 @@ const dynamicBaseQuery: BaseQueryFn<
 	unknown,
 	FetchBaseQueryError
 > = async (args, api, extraOptions) => {
-	const { uid, token }: { uid: string; token: string } =
-		JSON.parse(localStorage.getItem('user') as string) || '';
+	const {
+		auth: { token, uid },
+	} = api.getState() as RootState;
 
 	if (!uid || !token) {
 		return {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,4 @@
+export interface User {
+	token: string;
+	uid: string;
+}


### PR DESCRIPTION
### Что сделано

update logic of auth
1. При логине и регистрации в санке диспатчу данные для присвоения token и uid и пихаю в лс, при успешном ответе. 
2. В слайсе auth добавил поля token и uid. 
3. В reducer функция setIsAuth, которая присваивает значения этим полям + isAuth.  
4. В компоненте app при инициализации достается из хука лс значения token и uid, для диспатча setIsAuth(), чтобы 
а) можно было достать их значения в любом месте прилы;
б) для понимания вошел ли в аккаунт при перезагрузке

### Чек-лист

- [x] ПР имеет четкое **название**, короткое и описывающее его суть.
- [x] ПР имеет четкое **описание** того, что в рамках него было сделано.
- [x] Я провел **само-ревью** ПРа. Там нет кода, который я забыл удалить, случайно закоммитил и т.п.
- [x] ПР не содержит кода, который не соответствует цели ПРа.
